### PR TITLE
Also check for the presence of `node-gyp-build`

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ const isNative = pkg =>
     pkg.dependencies.bindings ||
     pkg.dependencies.prebuild ||
     pkg.dependencies.nan ||
-    pkg.dependencies['node-pre-gyp']
+    pkg.dependencies['node-pre-gyp'] ||
+    pkg.dependencies['node-gyp-build']
   ) ||
   pkg.gypfile ||
   pkg.binary


### PR DESCRIPTION
`node-gyp-build` is used by several modules using `prebuildify`.
One such example is `sodium-native`: https://github.com/sodium-friends/sodium-native/blob/ea065250bd5fd9f3129ae2f1c7a627248f78cd0b/package.json#L8